### PR TITLE
fix listen_in_thread

### DIFF
--- a/lib/pulsar/consumer.rb
+++ b/lib/pulsar/consumer.rb
@@ -45,7 +45,7 @@ module Pulsar
     end
 
     def listen_in_thread
-      Thread.new { listen }
+      Thread.new { listen {|*args| yield *args }}
     end
   end
 end


### PR DESCRIPTION
This should fix this error that I ran into when using listen_in_thread:
```
bundler: failed to load command: ./client.rb (./client.rb)
LocalJumpError: no block given (yield)
  /home/docker/.gem/ruby/2.6.0/bundler/gems/pulsar-client-ruby-f915f9680abd/lib/pulsar/consumer.rb:42:in `listen'
  /home/docker/.gem/ruby/2.6.0/bundler/gems/pulsar-client-ruby-f915f9680abd/lib/pulsar/consumer.rb:48:in `block in listen_in_thread'
```