### PR TITLE
fix typo (has? -> has_key?)

### DIFF
--- a/lib/pulsar/client/version.rb
+++ b/lib/pulsar/client/version.rb
@@ -19,6 +19,6 @@
 
 module Pulsar
   class Client
-    VERSION = "2.4.1-beta.2"
+    VERSION = "2.4.1-beta.3"
   end
 end

--- a/lib/pulsar/consumer_configuration.rb
+++ b/lib/pulsar/consumer_configuration.rb
@@ -36,7 +36,7 @@ module Pulsar
     module RubySideTweaks
       def initialize(config={})
         super()
-        self.consumer_type = config.consumer_type if config.has?(:consumer_type)
+        self.consumer_type = config.consumer_type if config.has_key?(:consumer_type)
       end
 
       def consumer_type


### PR DESCRIPTION
this fixes this error I got when importing this gem:

```bundler: failed to load command: ./client.rb (./client.rb)
NoMethodError: undefined method `has?' for {}:Hash
  /home/docker/.gem/ruby/2.6.0/gems/pulsar-client-2.4.1.pre.beta.2/lib/pulsar/consumer_configuration.rb:39:in `initialize'
  /usr/src/app/client.rb:19:in `new'
  /usr/src/app/client.rb:19:in `<top (required)>'```