### PR TITLE
fix consumer_type initializer

### DIFF
--- a/lib/pulsar/consumer_configuration.rb
+++ b/lib/pulsar/consumer_configuration.rb
@@ -36,7 +36,7 @@ module Pulsar
     module RubySideTweaks
       def initialize(config={})
         super()
-        self.consumer_type = config.consumer_type if config.has_key?(:consumer_type)
+        self.consumer_type = config[:consumer_type] if config.has_key?(:consumer_type)
       end
 
       def consumer_type


### PR DESCRIPTION
fixes this error:
```
bundler: failed to load command: ./client.rb (./client.rb)
NoMethodError: undefined method `consumer_type' for {:consumer_type=>:exclusive}:Hash
  /home/docker/.gem/ruby/2.6.0/gems/pulsar-client-2.4.1.pre.beta.4/lib/pulsar/consumer_configuration.rb:39:in `initialize'
```