### PR TITLE
allow partition keys when producing messages

### DIFF
--- a/ext/bindings/message.cpp
+++ b/ext/bindings/message.cpp
@@ -18,6 +18,10 @@ Message::Message(const std::string& data) {
   _msg = mb.build();
 }
 
+Message Message::fromMessage(const pulsar::Message& msg) {
+  return Message(msg);
+}
+
 Rice::String Message::getData() {
   std::string str((const char*)_msg.getData(), _msg.getLength());
   return Rice::String(str);
@@ -39,8 +43,8 @@ void bind_message(Module& module) {
     ;
 
   define_class_under<pulsar_rb::Message>(module, "Message")
-    .define_constructor(Constructor<pulsar_rb::Message, const pulsar::Message&>())
     .define_constructor(Constructor<pulsar_rb::Message, const std::string&>())
+    .define_singleton_method("from_message", &pulsar_rb::Message::fromMessage)
     .define_method("data", &pulsar_rb::Message::getData)
     .define_method("message_id", &pulsar_rb::Message::getMessageId)
     ;

--- a/ext/bindings/message.cpp
+++ b/ext/bindings/message.cpp
@@ -12,9 +12,12 @@ Rice::String MessageId::toString() {
   return Rice::String(ss.str());
 }
 
-Message::Message(const std::string& data) {
+Message::Message(const std::string& data, const std::string& partitionKey) {
   pulsar::MessageBuilder mb;
   mb.setContent(data);
+  if (!partitionKey.empty()) {
+    mb.setPartitionKey(partitionKey);
+  }
   _msg = mb.build();
 }
 
@@ -32,6 +35,10 @@ MessageId::ptr Message::getMessageId() {
   return MessageId::ptr(new MessageId(messageId));
 }
 
+Rice::String Message::getPartitionKey() {
+  return Rice::String(_msg.getPartitionKey());
+}
+
 }
 
 using namespace Rice;
@@ -43,9 +50,10 @@ void bind_message(Module& module) {
     ;
 
   define_class_under<pulsar_rb::Message>(module, "Message")
-    .define_constructor(Constructor<pulsar_rb::Message, const std::string&>())
+    .define_constructor(Constructor<pulsar_rb::Message, const std::string&, const std::string&>())
     .define_singleton_method("from_message", &pulsar_rb::Message::fromMessage)
     .define_method("data", &pulsar_rb::Message::getData)
     .define_method("message_id", &pulsar_rb::Message::getMessageId)
+    .define_method("partition_key", &pulsar_rb::Message::getPartitionKey)
     ;
 }

--- a/ext/bindings/message.hpp
+++ b/ext/bindings/message.hpp
@@ -23,6 +23,7 @@ namespace pulsar_rb {
     Message(const pulsar::Message& msg) : _msg(msg) {};
     Message(const std::string& data);
 
+    Message fromMessage(const pulsar::Message& msg);
     Rice::String getData();
     MessageId::ptr getMessageId();
 

--- a/ext/bindings/message.hpp
+++ b/ext/bindings/message.hpp
@@ -21,10 +21,11 @@ namespace pulsar_rb {
   public:
     pulsar::Message _msg;
     Message(const pulsar::Message& msg) : _msg(msg) {};
-    Message(const std::string& data);
+    Message(const std::string& data, const std::string& partitionKey);
 
     Message fromMessage(const pulsar::Message& msg);
     Rice::String getData();
+    Rice::String getPartitionKey();
     MessageId::ptr getMessageId();
 
     typedef Rice::Data_Object<Message> ptr;

--- a/ext/bindings/message.hpp
+++ b/ext/bindings/message.hpp
@@ -22,11 +22,13 @@ namespace pulsar_rb {
     pulsar::Message _msg;
     Message(const pulsar::Message& msg) : _msg(msg) {};
     Message(const std::string& data, const std::string& partitionKey);
+    void buildMessage(const std::string& data, const std::string& partitionKey);
 
-    Message fromMessage(const pulsar::Message& msg);
     Rice::String getData();
     Rice::String getPartitionKey();
     MessageId::ptr getMessageId();
+
+    void setPartitionKey(const std::string& partitionKey);
 
     typedef Rice::Data_Object<Message> ptr;
   };

--- a/lib/pulsar/client.rb
+++ b/lib/pulsar/client.rb
@@ -23,6 +23,7 @@ require 'pulsar/client_configuration'
 require 'pulsar/consumer'
 require 'pulsar/consumer_configuration'
 require 'pulsar/producer'
+require 'pulsar/message'
 
 module Pulsar
   class Client

--- a/lib/pulsar/message.rb
+++ b/lib/pulsar/message.rb
@@ -20,16 +20,18 @@
 require 'pulsar/bindings'
 
 module Pulsar
-  class Producer
+  class Message
     module RubySideTweaks
-      def send(message)
-        unless message.is_a?(Pulsar::Message)
-          message = Pulsar::Message.new(message)
-        end
-        super(message)
+      def partition_key=(partition_key)
+        # translate ruby's nil to C++ empty string
+        super(partition_key || "")
       end
     end
 
     prepend RubySideTweaks
+
+    def self.from_message(message)
+      new(message.data, message.partition_key)
+    end
   end
 end

--- a/lib/pulsar/producer.rb
+++ b/lib/pulsar/producer.rb
@@ -22,9 +22,9 @@ require 'pulsar/bindings'
 module Pulsar
   class Producer
     module RubySideTweaks
-      def send(message)
+      def send(message, partitionKey='')
         unless message.is_a?(Pulsar::Message)
-          message = Pulsar::Message.new(message)
+          message = Pulsar::Message.new(message, partitionKey)
         end
         super(message)
       end


### PR DESCRIPTION
* partition key defaults to the empty string in ruby-land, and is optional
* also makes some changes to the Message constructor
  * ruby doesn't allow overloaded constructors, so Rice ignores all but the last-defined constructor
  * replaced the Message(Message msg) constructor with a Message.from_message(Message msg) method, since Rice doesn't allow constructors to be associated with class methods
  * this is the reason that there is now only one Message constructor pushed to ruby-land, and it's the one that takes both data and partition key
  * it is possible to define default values in a Rice constructor, but since `producer.send` is providing the default value for partition_key, I didn't think it was necessary. this is up for discussion :)

TODO:
* make Message.from_message actually work
* if needed, that can be part of a later PR since it's not actually used anywhere in ruby-land

test plan:
* launch Pulsar standalone however you will and note the broker url
* in a new terminal:
  * `export PULSAR_BROKER_URI=pulsar://<your pulsar url and port>`
  * `bin/console`
  * `producer = Pulsar::Client.from_environment.create_producer("test")`
* in a second terminal:
  * the same export command as above, and `bin/console`
  * `consumer = Pulsar::Client.from_environment.subscribe("test", "consumer1")`
  * `msg = consumer.receive`
* in the first terminal:
  * `producer.send("test without key")`
* in the second terminal:
  * assert `msg.data` is "test without key"
  * assert `msg.partition_key` is the empty string
  * again, `msg = consumer.receive`
* in the first terminal:
  * `producer.send("test with key", "the key")`
* in the second terminal:
  * assert `msg.data` is "test with key"
  * assert `msg.partition_key` is "the key"
