### PR TITLE
Support partition key and ordering key on top of properties

### DIFF
--- a/ext/bindings/message.cpp
+++ b/ext/bindings/message.cpp
@@ -32,6 +32,8 @@ Message::Message(const std::string& data, Rice::Object arg = Rice::Object()) {
         }
       } else if (key == "partition_key") {
         mb.setPartitionKey(Rice::Object(it->value).to_s().str());
+      } else if (key == "ordering_key") {
+        mb.setOrderingKey(Rice::Object(it->value).to_s().str());
       } else {
         throw Rice::Exception(rb_eArgError, "Unknown keyword argument: %s", key.c_str());
       }
@@ -59,6 +61,10 @@ Rice::String Message::getPartitionKey() {
   return to_ruby(_msg.getPartitionKey());
 }
 
+Rice::String Message::getOrderingKey() {
+  return to_ruby(_msg.getOrderingKey());
+}
+
 }
 
 using namespace Rice;
@@ -77,5 +83,6 @@ void bind_message(Module& module) {
     .define_method("message_id", &pulsar_rb::Message::getMessageId)
     .define_method("properties", &pulsar_rb::Message::getProperties)
     .define_method("partition_key", &pulsar_rb::Message::getPartitionKey)
+    .define_method("ordering_key", &pulsar_rb::Message::getOrderingKey)
     ;
 }

--- a/ext/bindings/message.cpp
+++ b/ext/bindings/message.cpp
@@ -30,6 +30,8 @@ Message::Message(const std::string& data, Rice::Object arg = Rice::Object()) {
         if (value.rb_type() != T_NIL) {
           mb.setProperties(from_ruby<pulsar::StringMap>(value));
         }
+      } else if (key == "partition_key") {
+        mb.setPartitionKey(Rice::Object(it->value).to_s().str());
       } else {
         throw Rice::Exception(rb_eArgError, "Unknown keyword argument: %s", key.c_str());
       }
@@ -53,6 +55,10 @@ Rice::Hash Message::getProperties() {
   return to_ruby(_msg.getProperties());
 }
 
+Rice::String Message::getPartitionKey() {
+  return to_ruby(_msg.getPartitionKey());
+}
+
 }
 
 using namespace Rice;
@@ -70,5 +76,6 @@ void bind_message(Module& module) {
     .define_method("data", &pulsar_rb::Message::getData)
     .define_method("message_id", &pulsar_rb::Message::getMessageId)
     .define_method("properties", &pulsar_rb::Message::getProperties)
+    .define_method("partition_key", &pulsar_rb::Message::getPartitionKey)
     ;
 }

--- a/ext/bindings/message.hpp
+++ b/ext/bindings/message.hpp
@@ -27,6 +27,7 @@ namespace pulsar_rb {
     Rice::String getData();
     MessageId::ptr getMessageId();
     Rice::Hash getProperties();
+    Rice::String getPartitionKey();
 
     typedef Rice::Data_Object<Message> ptr;
   };

--- a/ext/bindings/message.hpp
+++ b/ext/bindings/message.hpp
@@ -28,6 +28,7 @@ namespace pulsar_rb {
     MessageId::ptr getMessageId();
     Rice::Hash getProperties();
     Rice::String getPartitionKey();
+    Rice::String getOrderingKey();
 
     typedef Rice::Data_Object<Message> ptr;
   };

--- a/spec/pulsar/message_spec.rb
+++ b/spec/pulsar/message_spec.rb
@@ -82,6 +82,28 @@ RSpec.describe Pulsar::Message do
       end
     end
 
+    describe "ordering_key" do
+      it "defaults to blank string" do
+        m = described_class.new("payload")
+        expect(m.ordering_key).to eq("")
+      end
+
+      it "accepts ordering key" do
+        m = described_class.new("payload", ordering_key: "foo")
+        expect(m.ordering_key).to eq("foo")
+      end
+
+      it "accepts nil ordering key" do
+        m = described_class.new("payload", ordering_key: nil)
+        expect(m.ordering_key).to eq("")
+      end
+
+      it "stringifies ordering key" do
+        m = described_class.new("payload", ordering_key: ["o"])
+        expect(m.ordering_key).to eq(%(["o"]))
+      end
+    end
+
     describe "errors" do
       it "rejects second arg that is not a hash" do
         expect do

--- a/spec/pulsar/message_spec.rb
+++ b/spec/pulsar/message_spec.rb
@@ -60,6 +60,28 @@ RSpec.describe Pulsar::Message do
       end
     end
 
+    describe "partition_key" do
+      it "defaults to blank string" do
+        m = described_class.new("payload")
+        expect(m.partition_key).to eq("")
+      end
+
+      it "accepts partition key" do
+        m = described_class.new("payload", partition_key: "foo")
+        expect(m.partition_key).to eq("foo")
+      end
+
+      it "accepts nil key" do
+        m = described_class.new("payload", partition_key: nil)
+        expect(m.partition_key).to eq("")
+      end
+
+      it "stringifies partition key" do
+        m = described_class.new("payload", partition_key: :bar)
+        expect(m.partition_key).to eq("bar")
+      end
+    end
+
     describe "errors" do
       it "rejects second arg that is not a hash" do
         expect do

--- a/spec/pulsar/producer_spec.rb
+++ b/spec/pulsar/producer_spec.rb
@@ -52,6 +52,7 @@ RSpec.describe Pulsar::Producer do
           ProducerTest.new.send(
             "payload",
             properties: {"k" => "v"},
+            partition_key: "foo",
           )
         }
 
@@ -61,6 +62,10 @@ RSpec.describe Pulsar::Producer do
 
         it "sets properties" do
           expect(subject.properties).to eq({"k" => "v"})
+        end
+
+        it "sets partition_key" do
+          expect(subject.partition_key).to eq("foo")
         end
       end
     end

--- a/spec/pulsar/producer_spec.rb
+++ b/spec/pulsar/producer_spec.rb
@@ -53,6 +53,7 @@ RSpec.describe Pulsar::Producer do
             "payload",
             properties: {"k" => "v"},
             partition_key: "foo",
+            ordering_key: "mine",
           )
         }
 
@@ -66,6 +67,10 @@ RSpec.describe Pulsar::Producer do
 
         it "sets partition_key" do
           expect(subject.partition_key).to eq("foo")
+        end
+
+        it "sets ordering_key" do
+          expect(subject.ordering_key).to eq("mine")
         end
       end
     end


### PR DESCRIPTION
This builds upon the "properties" pullreq (#7) by adding support for partition_key and ordering_key to the accepted keyword arguments of the the constructor.