### PR TITLE
Adding close calls to producer and consumer.

### DIFF
--- a/ext/bindings/consumer.cpp
+++ b/ext/bindings/consumer.cpp
@@ -56,6 +56,7 @@ void bind_consumer(Module &module) {
     .define_method("receive", &pulsar_rb::Consumer::receive, (Arg("timeout_ms") = 0))
     .define_method("acknowledge", &pulsar_rb::Consumer::acknowledge)
     .define_method("negative_acknowledge", &pulsar_rb::Consumer::negative_acknowledge)
+    .define_method("close", &pulsar_rb::Consumer::close)
     ;
 
   define_enum<pulsar::ConsumerType>("ConsumerType", module)

--- a/ext/bindings/consumer.cpp
+++ b/ext/bindings/consumer.cpp
@@ -59,7 +59,7 @@ void* consumer_close_worker(void* taskPtr) {
 
 void Consumer::close() {
   consumer_close_task task = { _consumer };
-  rb_thread_call_without_gvl(&consumer_close_task, &task, RUBY_UBF_IO, nullptr);
+  rb_thread_call_without_gvl(&consumer_close_worker, &task, RUBY_UBF_IO, nullptr);
   CheckResult(task.result);
 }
 

--- a/ext/bindings/consumer.hpp
+++ b/ext/bindings/consumer.hpp
@@ -17,6 +17,7 @@ namespace pulsar_rb {
     Message::ptr receive(unsigned int timeout_ms=0);
     void acknowledge(const Message& message);
     void negative_acknowledge(const Message& message);
+    void close();
 
     typedef Rice::Data_Object<Consumer> ptr;
   };

--- a/ext/bindings/producer.cpp
+++ b/ext/bindings/producer.cpp
@@ -34,6 +34,7 @@ void bind_producer(Module& module) {
   define_class_under<pulsar_rb::Producer>(module, "Producer")
     .define_constructor(Constructor<pulsar_rb::Producer>())
     .define_method("send", &pulsar_rb::Producer::send)
+    .define_method("close", &pulsar_rb::Producer::close)
     ;
 
   define_class_under<pulsar_rb::ProducerConfiguration>(module, "ProducerConfiguration")

--- a/ext/bindings/producer.hpp
+++ b/ext/bindings/producer.hpp
@@ -15,6 +15,7 @@ namespace pulsar_rb {
     Producer(const pulsar::Producer& producer) : _producer(producer) {}
 
     void send(const Message& message);
+    void close();
 
     typedef Rice::Data_Object<Producer> ptr;
   };


### PR DESCRIPTION
Currently, the close calls were not exposed by the producer and consumer.  Although closing a client closes its associated producers and consumers but sometimes people may create a single client and use that to keep creating multiple producers and consumers.
Now the producer and consumer have the close calls available.