### PR TITLE
Adding close call to producer and consumer

### DIFF
--- a/ext/bindings/consumer.hpp
+++ b/ext/bindings/consumer.hpp
@@ -17,6 +17,7 @@ namespace pulsar_rb {
     Message::ptr receive(unsigned int timeout_ms=0);
     void acknowledge(const Message& message);
     void negative_acknowledge(const Message& message);
+    void close();
 
     typedef Rice::Data_Object<Consumer> ptr;
   };

--- a/ext/bindings/producer.hpp
+++ b/ext/bindings/producer.hpp
@@ -15,6 +15,7 @@ namespace pulsar_rb {
     Producer(const pulsar::Producer& producer) : _producer(producer) {}
 
     void send(const Message& message);
+    void close();
 
     typedef Rice::Data_Object<Producer> ptr;
   };


### PR DESCRIPTION
Currently, the close calls are not exposed at the producer and consumer level. One has to call the client close to close all associated producers and consumers. But sometimes a client may be used to keep creating producers and consumers and then closing them. Added the close calls to producer and consumer.