### PR TITLE
feat(client-configuration): load and use PULSAR_CLIENT_CONF from environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,9 @@ the `.pre` suffix in the Gemfile to install it via Bundler.
 Setup and basic `consumer.receive` example:
 
 ```ruby
-# have these in your shell with appropriate values
+# use a standard Pulsar client config (see https://github.com/apache/pulsar/blob/master/conf/client.conf)
+# export PULSAR_CLIENT_CONF=/path/to/your/client/conf/client_conf.conf
+# OR, if not present have these in your shell with appropriate values
 # export PULSAR_BROKER_URI=pulsar://your-pulsar-broker:6651
 # export PULSAR_CERT_PATH=/path/to/your/pulsar-ca.pem
 # export PULSAR_AUTH_TOKEN=your-auth-token

--- a/bin/example-consumer
+++ b/bin/example-consumer
@@ -28,9 +28,12 @@ unless ARGV.size >= 1 && ARGV.size <= 2 && Pulsar::Client.sufficient_environment
   puts
   puts "If not specified, the consumer name defaults to 'example-consumer'."
   puts
-  puts "Additionally, the PULSAR_BROKER_URI environment variable must be set. Optional"
-  puts "PULSAR_CERT_PATH and PULSAR_AUTH_TOKEN environment variables are also"
-  puts "recognized."
+  puts "If set, PULSAR_CLIENT_CONF is loaded and used as a configuration."
+  puts "Broker URI, TLS settings and the authorization token to use is loaded"
+  puts "from this file."
+  puts "If this variable is not present, the PULSAR_BROKER_URI environment variable"
+  puts "must be set. In this case PULSAR_CERT_PATH and PULSAR_AUTH_TOKEN environment"
+  puts "variables are also recognized."
   exit 1
 end
 

--- a/bin/example-producer
+++ b/bin/example-producer
@@ -26,9 +26,12 @@ require "pulsar/client"
 unless ARGV.size == 1 && Pulsar::Client.sufficient_environment?
   puts "Usage: #{__FILE__} <topic>"
   puts
-  puts "Additionally, the PULSAR_BROKER_URI environment variable must be set. Optional"
-  puts "PULSAR_CERT_PATH and PULSAR_AUTH_TOKEN environment variables are also"
-  puts "recognized."
+  puts "If set, PULSAR_CLIENT_CONF is loaded and used as a configuration."
+  puts "Broker URI, TLS settings and the authorization token to use is loaded"
+  puts "from this file."
+  puts "If this variable is not present, the PULSAR_BROKER_URI environment variable"
+  puts "must be set. In this case PULSAR_CERT_PATH and PULSAR_AUTH_TOKEN environment"
+  puts "variables are also recognized."
   exit 1
 end
 

--- a/lib/pulsar/client.rb
+++ b/lib/pulsar/client.rb
@@ -52,8 +52,8 @@ module Pulsar
     end
 
     def self.from_environment(config={})
-      broker_uri = config[:broker_uri] || ENV['PULSAR_BROKER_URI']
       config = Pulsar::ClientConfiguration.from_environment(config)
+      broker_uri = config[:broker_uri] || ENV['PULSAR_BROKER_URI']
       new(broker_uri, config)
     end
   end

--- a/lib/pulsar/client_configuration.rb
+++ b/lib/pulsar/client_configuration.rb
@@ -21,6 +21,10 @@ require 'pulsar/bindings'
 
 module Pulsar
   class ClientConfiguration
+    AUTH_TOKEN_PLUGIN_NAME = 'org.apache.pulsar.client.impl.auth.AuthenticationToken'.freeze
+    CLIENT_CONF_KEY_VALUE_SEPARATOR = ': '
+    FILE_URL_PREFIX = 'file://'.freeze
+
     def self.from(config)
       case config
       when self then config # already a config object
@@ -41,17 +45,82 @@ module Pulsar
       if ENV.key?('PULSAR_AUTH_TOKEN')
         env_config[:authentication_token] = ENV['PULSAR_AUTH_TOKEN']
       end
+      if ENV.key?('PULSAR_CLIENT_CONF')
+        env_config.merge!(read_from_client_conf(ENV['PULSAR_CLIENT_CONF']))
+      end
       self.from(env_config.merge(config))
+    end
+
+    # Load configuration from PULSAR_CLIENT_CONF
+    # refer to (see https://github.com/apache/pulsar/blob/master/conf/client.conf)
+    def self.read_from_client_conf(pulsar_client_conf_file)
+      client_config = {}
+      # Read the client config as a Ruby Hashmap
+      pulsar_config = read_config(pulsar_client_conf_file)
+      # Attempt to read as many configuration as possible from the client configuration
+
+      # If a TLS certificate had been given, use it
+      if pulsar_config.has_key? 'tlsTrustCertsFilePath'
+        client_config[:use_tls] = true
+        client_config[:tls_trust_certs_file_path] = pulsar_config['tlsTrustCertsFilePath']
+      end
+      # If 'TLS enable hostname verification' is false, then switch it off in config
+      if (pulsar_config.has_key? 'tlsEnableHostnameVerification') &&
+          pulsar_config['tlsEnableHostnameVerification'].eql?('false')
+        client_config[:tls_validate_hostname] = false
+      end
+      # If 'TLS allow insecure connection' is false, then switch it off in config
+      if (pulsar_config.has_key? 'tlsAllowInsecureConnection') &&
+          pulsar_config['tlsAllowInsecureConnection'].eql?('false')
+        client_config[:tls_allow_insecure_connection] = false
+      end
+      # If token-based authentication is used, load the token
+      # Currently only loading from files is supported
+      if (pulsar_config['authPlugin'].eql? AUTH_TOKEN_PLUGIN_NAME) &&
+          pulsar_config['authParams'].start_with?(FILE_URL_PREFIX)
+        # read the first line from the token file
+        token = File.readlines(pulsar_config['authParams'].gsub(FILE_URL_PREFIX, ''))[0]
+        # store the token to the config
+        client_config[:authentication_token] = token
+      end
+      # If we have a broker service URI, use it
+      client_config[:broker_uri] = pulsar_config['brokerServiceUrl'] if pulsar_config.has_key? 'brokerServiceUrl'
+      client_config
+    end
+
+    # read Pulsar client configuration as a Hashmap from a client configuration file
+    def self.read_config(pulsar_config_file)
+      result = {}
+      begin
+        config_file_content = File.readlines(pulsar_config_file)
+        config_key_values = config_file_content.map do |line|
+          key_value = line.split(CLIENT_CONF_KEY_VALUE_SEPARATOR, 2)
+          [key_value[0], key_value[1].strip]
+        end
+        config_key_values.to_h
+        result = config_key_values
+      rescue Errno::ENOENT => e
+        warn("Could not load client config file '#{pulsar_config_file}'. Exception was #{e}.")
+      end
+      return result
     end
 
     module RubySideTweaks
       def initialize(config={})
         super()
+        # store client configuration inside class
+        @config = config
         populate(config)
       end
     end
 
     prepend RubySideTweaks
+
+    # serve the client configuration to peer objects
+    # (eg. we need to configure the 'broker URI' in a different way)
+    def [](key)
+      @config[key]
+    end
 
     def populate(config={})
       populate_one(config, :authentication_token)

--- a/lib/pulsar/client_configuration.rb
+++ b/lib/pulsar/client_configuration.rb
@@ -34,21 +34,23 @@ module Pulsar
       end
     end
 
-    def self.from_environment(config={})
-      env_config = {}
-      if ENV.key?('PULSAR_CERT_PATH')
-        env_config[:use_tls] = true
-        env_config[:tls_allow_insecure_connection] = false
-        env_config[:tls_validate_hostname] = false
-        env_config[:tls_trust_certs_file_path] = ENV['PULSAR_CERT_PATH']
+    # Creates a client configuration from a custom and environment configuration
+    # (the environment configuration defaults to OS's ENV)
+    def self.from_environment(config={}, environment=ENV.to_h)
+      environment_config = {}
+      if environment.has_key?('PULSAR_CERT_PATH')
+        environment_config[:use_tls] = true
+        environment_config[:tls_allow_insecure_connection] = false
+        environment_config[:tls_validate_hostname] = false
+        environment_config[:tls_trust_certs_file_path] = environment['PULSAR_CERT_PATH']
       end
-      if ENV.key?('PULSAR_AUTH_TOKEN')
-        env_config[:authentication_token] = ENV['PULSAR_AUTH_TOKEN']
+      if environment.has_key?('PULSAR_AUTH_TOKEN')
+        environment_config[:authentication_token] = environment['PULSAR_AUTH_TOKEN']
       end
-      if ENV.key?('PULSAR_CLIENT_CONF')
-        env_config.merge!(read_from_client_conf(ENV['PULSAR_CLIENT_CONF']))
+      if environment.has_key?('PULSAR_CLIENT_CONF')
+        environment_config.merge!(read_from_client_conf(environment['PULSAR_CLIENT_CONF']))
       end
-      self.from(env_config.merge(config))
+      self.from(environment_config.merge(config))
     end
 
     # Load configuration from PULSAR_CLIENT_CONF

--- a/spec/pulsar/client_configuration_spec.rb
+++ b/spec/pulsar/client_configuration_spec.rb
@@ -1,0 +1,178 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+require 'tempfile'
+
+RSpec.describe Pulsar::ClientConfiguration do
+  it 'use authentication token from environment' do
+    test_env = {
+      'PULSAR_AUTH_TOKEN' => 'example.token.abcdef123'
+    }
+    config = Pulsar::ClientConfiguration.from_environment({}, test_env)
+    expect(config[:authentication_token]).to eq('example.token.abcdef123')
+  end
+
+  it 'use client cert from environment' do
+    test_env = {
+      'PULSAR_CERT_PATH' => '/path/to/cert.pem'
+    }
+    config = Pulsar::ClientConfiguration.from_environment({}, test_env)
+    expect(config[:use_tls]).to eq(true)
+    expect(config[:tls_allow_insecure_connection]).to eq(false)
+    expect(config[:tls_validate_hostname]).to eq(false)
+    expect(config[:tls_trust_certs_file_path]).to eq('/path/to/cert.pem')
+  end
+
+  it 'do not use authentication token when plugin is not set' do
+    test_token = create_temp_config(
+      'example.token.abcdef123'
+    )
+    test_config = create_temp_config(
+      "authParams: file://#{test_token.path}"
+    )
+    begin
+      test_env = {
+        'PULSAR_CLIENT_CONF' => test_config.path
+      }
+      config = Pulsar::ClientConfiguration.from_environment({}, test_env)
+      expect(config[:authentication_token]).to eq(nil)
+    ensure
+      test_config.unlink
+      test_token.unlink
+    end
+  end
+
+  it 'overwrite token with client configuration' do
+    test_token = create_temp_config(
+      'example.token.abcdef123.from.file'
+    )
+    test_config = create_temp_config(
+      "authPlugin: org.apache.pulsar.client.impl.auth.AuthenticationToken\n"\
+      "authParams: file://#{test_token.path}"
+    )
+    begin
+      test_env = {
+        'PULSAR_AUTH_TOKEN' => 'example.token.abcdef123.from.env.shall.be.overwritten',
+        'PULSAR_CLIENT_CONF' => test_config.path
+      }
+      config = Pulsar::ClientConfiguration.from_environment({}, test_env)
+      expect(config[:authentication_token]).to eq('example.token.abcdef123.from.file')
+    ensure
+      test_config.unlink
+      test_token.unlink
+    end
+  end
+
+  it 'overwrite certificate with client configuration' do
+    test_config = create_temp_config(
+      "tlsTrustCertsFilePath: /cert/file/from/client/config/ca.pem\n"
+    )
+    begin
+      test_env = {
+        'PULSAR_CERT_PATH' => '/path/to/a/cert/that/shall/not/be/used',
+        'PULSAR_CLIENT_CONF' => test_config.path
+      }
+      config = Pulsar::ClientConfiguration.from_environment({}, test_env)
+      expect(config[:tls_trust_certs_file_path]).to eq('/cert/file/from/client/config/ca.pem')
+    ensure
+      test_config.unlink
+    end
+  end
+
+  it 'load all supported configuration from configuration file' do
+    test_token = create_temp_config(
+      'example.token.abcdef123.from.file'
+    )
+    test_config = create_temp_config(
+      "authPlugin: org.apache.pulsar.client.impl.auth.AuthenticationToken\n"\
+      "authParams: file://#{test_token.path}\n"\
+      "brokerServiceUrl: pulsar+ssl://test.broker.uri:6651\n"\
+      "tlsTrustCertsFilePath: /test/cert/file/ca.pem\n"\
+      "tlsAllowInsecureConnection: false\n"\
+      "tlsEnableHostnameVerification: false\n"
+    )
+    begin
+      test_env = {
+        'PULSAR_CLIENT_CONF' => test_config.path
+      }
+      config = Pulsar::ClientConfiguration.from_environment({}, test_env)
+      expect(config[:authentication_token]).to eq('example.token.abcdef123.from.file')
+      expect(config[:broker_uri]).to eq('pulsar+ssl://test.broker.uri:6651')
+      expect(config[:tls_allow_insecure_connection]).to eq(false)
+      expect(config[:tls_validate_hostname]).to eq(false)
+      expect(config[:tls_trust_certs_file_path]).to eq('/test/cert/file/ca.pem')
+      expect(config[:use_tls]).to eq(true)
+    ensure
+      test_config.unlink
+      test_token.unlink
+    end
+  end
+
+  it 'handle when configuration file is not found without exceptions' do
+    test_env = {
+      'PULSAR_CLIENT_CONF' => '/this/file/does/not/exists'
+    }
+    config = Pulsar::ClientConfiguration.from_environment({}, test_env)
+    expect(config[:authentication_token]).to eq(nil)
+    expect(config[:broker_uri]).to eq(nil)
+    expect(config[:tls_allow_insecure_connection]).to eq(nil)
+    expect(config[:tls_validate_hostname]).to eq(nil)
+    expect(config[:tls_trust_certs_file_path]).to eq(nil)
+    expect(config[:use_tls]).to eq(nil)
+  end
+
+  it 'handle when token file is not found without exceptions' do
+    test_config = create_temp_config(
+      "authPlugin: org.apache.pulsar.client.impl.auth.AuthenticationToken\n"\
+      "authParams: file:///missing/token/file.txt"
+    )
+    begin
+      test_env = {
+        'PULSAR_CLIENT_CONF' => test_config.path
+      }
+      config = Pulsar::ClientConfiguration.from_environment({}, test_env)
+      expect(config[:authentication_token]).to eq(nil)
+    ensure
+      test_config.unlink
+    end
+  end
+
+  it 'do not load auth params with incorrect prefix' do
+    # the authParams has a missing schema in this config
+    test_config = create_temp_config(
+      'authPlugin: org.apache.pulsar.client.impl.auth.AuthenticationToken\n'\
+      'authParams: /missing/token/file.txt'
+    )
+    begin
+      test_env = {
+        'PULSAR_CLIENT_CONF' => test_config.path
+      }
+      config = Pulsar::ClientConfiguration.from_environment({}, test_env)
+      expect(config[:authentication_token]).to eq(nil)
+    ensure
+      test_config.unlink
+    end
+  end
+end
+
+def create_temp_config(content)
+  file = Tempfile.new('pulsar-ruby-client-configuration-test')
+  file.write(content)
+  file.close
+  file
+end


### PR DESCRIPTION
Like the official `pulsar-client` command line tool (https://pulsar.apache.org/docs/en/reference-cli-tools/#pulsar-client), the Ruby client could also leverage using the Pulsar client configuration format described here: `https://github.com/apache/pulsar/blob/master/conf/client.conf`. This is usually stored in environment variable `PULSAR_CLIENT_CONF`. This would be beneficial, since both tools can be used without the need to set additional environment variables (containing the same information). 

Currently `PULSAR_BROKER_URI`, `PULSAR_AUTH_TOKEN` and `PULSAR_CERT_PATH` need to be set, but these values can be loaded from a client configuration (and, if clients only have `PULSAR_CLIENT_CONF`, then they are responsible for creating this environment from it):

- `PULSAR_BROKER_URI` from `brokerServiceUrl`
- `PULSAR_AUTH_TOKEN` from `authParams` when `authPlugin` is `org.apache.pulsar.client.impl.auth.AuthenticationToken`
- `PULSAR_CERT_PATH` from `tlsTrustCertsFilePath`

The proposal changes the code in a way so that if `PULSAR_CLIENT_CONF` is set, the client can handle it as "environment" configuration and load it via `from_environment`. Not all configuration values need to be set, but whenever present, the client configuration is used instead of individual environment variables (this is up for debate though).

Please let me know what do you think about this change.