### PR TITLE
Add CI support to project

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,14 @@ sudo: false
 language: ruby
 rvm:
   - 2.4.3
-before_install: gem install bundler -v 1.16.1
+install:
+  - sudo apt-get update
+  - sudo apt-get -y install apt-utils automake
+  - wget https://archive.apache.org/dist/pulsar/pulsar-2.4.1/DEB/apache-pulsar-client.deb
+  - wget https://archive.apache.org/dist/pulsar/pulsar-2.4.1/DEB/apache-pulsar-client-dev.deb
+  - sudo apt-get -y install ./apache-pulsar-client.deb
+  - sudo apt-get -y install ./apache-pulsar-client-dev.deb
+  - gem install bundler -v 1.16.1
+  - bundle install
+script:
+  - rake

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,18 +1,18 @@
 PATH
   remote: .
   specs:
-    pulsar-client (0.0.1)
-      rake-compiler
-      rice
+    pulsar-client (2.4.1.pre.beta.4)
+      rake-compiler (~> 1.0)
+      rice (~> 2.1)
 
 GEM
   remote: https://rubygems.org/
   specs:
     diff-lcs (1.3)
     rake (10.5.0)
-    rake-compiler (1.0.7)
+    rake-compiler (1.1.1)
       rake
-    rice (2.1.3)
+    rice (2.2.0)
     rspec (3.8.0)
       rspec-core (~> 3.8.0)
       rspec-expectations (~> 3.8.0)

--- a/Rakefile
+++ b/Rakefile
@@ -3,7 +3,7 @@ require "rake/extensiontask"
 
 RSpec::Core::RakeTask.new(:spec)
 
-task :default => :spec
+task :default => [:compile, :spec]
 
 Rake::ExtensionTask.new "bindings" do |ext|
   ext.lib_dir = "lib/pulsar"

--- a/ext/bindings/extconf.rb
+++ b/ext/bindings/extconf.rb
@@ -1,3 +1,4 @@
 require 'mkmf-rice'
 $LOCAL_LIBS << "-lpulsar"
+$CXXFLAGS += " -std=c++11 "
 create_makefile('pulsar/bindings')

--- a/ext/bindings/util.cpp
+++ b/ext/bindings/util.cpp
@@ -44,10 +44,6 @@ VALUE rb_ePulsarError_TopicTerminated = Qnil;
 VALUE rb_ePulsarError_CryptoError = Qnil;
 VALUE rb_ePulsarError_IncompatibleSchema = Qnil;
 VALUE rb_ePulsarError_ConsumerAssignError = Qnil;
-VALUE rb_ePulsarError_CumulativeAcknowledgementNotAllowedError = Qnil;
-VALUE rb_ePulsarError_TransactionCoordinatorNotFoundError = Qnil;
-VALUE rb_ePulsarError_InvalidTxnStatusError = Qnil;
-VALUE rb_ePulsarError_NotAllowedError = Qnil;
 
 void bind_errors(Module &module) {
   rb_ePulsarError = rb_define_class_under(module.value(), "Error", rb_eStandardError);
@@ -87,10 +83,6 @@ void bind_errors(Module &module) {
   rb_ePulsarError_CryptoError = rb_define_class_under(rb_ePulsarError, "CryptoError", rb_ePulsarError);
   rb_ePulsarError_IncompatibleSchema = rb_define_class_under(rb_ePulsarError, "IncompatibleSchema", rb_ePulsarError);
   rb_ePulsarError_ConsumerAssignError = rb_define_class_under(rb_ePulsarError, "ConsumerAssignError", rb_ePulsarError);
-  rb_ePulsarError_CumulativeAcknowledgementNotAllowedError = rb_define_class_under(rb_ePulsarError, "CumulativeAcknowledgementNotAllowedError", rb_ePulsarError);
-  rb_ePulsarError_TransactionCoordinatorNotFoundError = rb_define_class_under(rb_ePulsarError, "TransactionCoordinatorNotFoundError", rb_ePulsarError);
-  rb_ePulsarError_InvalidTxnStatusError = rb_define_class_under(rb_ePulsarError, "InvalidTxnStatusError", rb_ePulsarError);
-  rb_ePulsarError_NotAllowedError = rb_define_class_under(rb_ePulsarError, "NotAllowedError", rb_ePulsarError);
 }
 
 void CheckResult(pulsar::Result res) {
@@ -168,14 +160,6 @@ void CheckResult(pulsar::Result res) {
         throw Exception(rb_ePulsarError_IncompatibleSchema, "Specified schema is incompatible with the topic's schema"); break;
       case pulsar::ResultConsumerAssignError:
         throw Exception(rb_ePulsarError_ConsumerAssignError, "Error when a new consumer connected but can't assign messages to this consumer"); break;
-      case pulsar::ResultCumulativeAcknowledgementNotAllowedError:
-        throw Exception(rb_ePulsarError_CumulativeAcknowledgementNotAllowedError, "Not allowed to call cumulativeAcknowledgement in Shared and Key_Shared subscription mode"); break;
-      case pulsar::ResultTransactionCoordinatorNotFoundError:
-        throw Exception(rb_ePulsarError_TransactionCoordinatorNotFoundError, "Transaction coordinator not found"); break;
-      case pulsar::ResultInvalidTxnStatusError:
-        throw Exception(rb_ePulsarError_InvalidTxnStatusError, "Invalid txn status error"); break;
-      case pulsar::ResultNotAllowedError:
-        throw Exception(rb_ePulsarError_NotAllowedError, "Not allowed"); break;
 
       default:
         throw Exception(rb_ePulsarError, "unexpected pulsar exception: %d", res);

--- a/spec/pulsar/ext/bindings.cpp
+++ b/spec/pulsar/ext/bindings.cpp
@@ -43,10 +43,6 @@ void check_result_TopicTerminated();
 void check_result_CryptoError();
 void check_result_IncompatibleSchema();
 void check_result_ConsumerAssignError();
-void check_result_CumulativeAcknowledgementNotAllowedError();
-void check_result_TransactionCoordinatorNotFoundError();
-void check_result_InvalidTxnStatusError();
-void check_result_NotAllowedError();
 
 void Init_bindings()
 {
@@ -88,10 +84,6 @@ void Init_bindings()
     .define_singleton_method("check_result_CryptoError", &check_result_CryptoError)
     .define_singleton_method("check_result_IncompatibleSchema", &check_result_IncompatibleSchema)
     .define_singleton_method("check_result_ConsumerAssignError", &check_result_ConsumerAssignError)
-    .define_singleton_method("check_result_CumulativeAcknowledgementNotAllowedError", &check_result_CumulativeAcknowledgementNotAllowedError)
-    .define_singleton_method("check_result_TransactionCoordinatorNotFoundError", &check_result_TransactionCoordinatorNotFoundError)
-    .define_singleton_method("check_result_InvalidTxnStatusError", &check_result_InvalidTxnStatusError)
-    .define_singleton_method("check_result_NotAllowedError", &check_result_NotAllowedError)
     ;
 
 }
@@ -133,7 +125,4 @@ void check_result_TopicTerminated() { CheckResult(pulsar::ResultTopicTerminated)
 void check_result_CryptoError() { CheckResult(pulsar::ResultCryptoError); }
 void check_result_IncompatibleSchema() { CheckResult(pulsar::ResultIncompatibleSchema); }
 void check_result_ConsumerAssignError() { CheckResult(pulsar::ResultConsumerAssignError); }
-void check_result_CumulativeAcknowledgementNotAllowedError() { CheckResult(pulsar::ResultCumulativeAcknowledgementNotAllowedError); }
-void check_result_TransactionCoordinatorNotFoundError() { CheckResult(pulsar::ResultTransactionCoordinatorNotFoundError); }
-void check_result_InvalidTxnStatusError() { CheckResult(pulsar::ResultInvalidTxnStatusError); }
-void check_result_NotAllowedError() { CheckResult(pulsar::ResultNotAllowedError); }
+

--- a/spec/pulsar/ext/extconf.rb
+++ b/spec/pulsar/ext/extconf.rb
@@ -1,0 +1,3 @@
+require 'mkmf-rice'
+$CXXFLAGS += ' -std=c++11 '
+create_makefile('bindings')

--- a/spec/pulsar/ext_spec.rb
+++ b/spec/pulsar/ext_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe "pulsar ext" do
 
   before(:all) do
     Dir.chdir(EXT_DIR) do
-      system(%(#{RUBY} -rmkmf-rice -e "create_makefile('bindings')"))
+      system("#{RUBY} ./extconf.rb")
       system("make clean all")
     end
     require_relative "#{File.join(".", "ext", "bindings")}"
@@ -149,18 +149,6 @@ RSpec.describe "pulsar ext" do
     end
     it "raises ConsumerAssignError" do
       expect { PulsarTestExt.check_result_ConsumerAssignError }.to raise_exception(Pulsar::Error::ConsumerAssignError)
-    end
-    it "raises CumulativeAcknowledgementNotAllowedError" do
-      expect { PulsarTestExt.check_result_CumulativeAcknowledgementNotAllowedError }.to raise_exception(Pulsar::Error::CumulativeAcknowledgementNotAllowedError)
-    end
-    it "raises TransactionCoordinatorNotFoundError" do
-      expect { PulsarTestExt.check_result_TransactionCoordinatorNotFoundError }.to raise_exception(Pulsar::Error::TransactionCoordinatorNotFoundError)
-    end
-    it "raises InvalidTxnStatusError" do
-      expect { PulsarTestExt.check_result_InvalidTxnStatusError }.to raise_exception(Pulsar::Error::InvalidTxnStatusError)
-    end
-    it "raises NotAllowedError" do
-      expect { PulsarTestExt.check_result_NotAllowedError }.to raise_exception(Pulsar::Error::NotAllowedError)
     end
   end
 end


### PR DESCRIPTION
Enable CI support on project. For the time being, do compilation and run basic integration tests (see the Development section in README.md for details on this.)

The following was done in the scope of this PR:
- Updated travis.yml to install dependencies (2.4.1 version of the C++ Pulsar client)
- Added a compiler flag to enable compilation of the C++ part of the client
- Some error codes needed to be removed from the code, since they were introduced after 2.4.1. I have added an issue to fix/reintroduce these in a later change, when we upgrade the client to 2.7.0.